### PR TITLE
New features

### DIFF
--- a/app.json
+++ b/app.json
@@ -74,6 +74,19 @@
       },
       "settings": [
         {
+          "id": "is_solarpanel",
+          "type": "checkbox",
+          "value": false,
+          "label": {
+            "en": "Solar plant / Inverter",
+            "de": "Solaranlage / Wechselrichter"
+          },
+          "hint": {
+            "en": "Is the meter an Inverter of a solar plant?",
+            "de": "Ist der Zähler ein Wechselrichter einer Solaranlage?"
+          }
+        },
+        {
           "type": "group",
           "label": {
             "en": "Measure",
@@ -112,8 +125,8 @@
                 "de": "Faktor für Wert Eigenschaft"
               },
               "hint": {
-                "en": "The property of the incoming json that represents the measurement value.",
-                "de": "Das json Property, welches den Wert für die Leistung enthält."
+                "en": "A factor to scale the measurement value.",
+                "de": "Ein Faktor zum skalieren des Messwertes"
               }
             }
           ]
@@ -157,8 +170,8 @@
                 "de": "Faktor für Wert Eigenschaft"
               },
               "hint": {
-                "en": "The property of the incoming json that represents the metering value.",
-                "de": "Das json Property, welches den Wert für die Energie enthält."
+                "en": "A factor to scale the measurement value.",
+                "de": "Ein Faktor zum skalieren des Messwertes"
               }
             }
           ]

--- a/app.json
+++ b/app.json
@@ -103,6 +103,18 @@
                 "en": "The property of the incoming json that represents the measurement value.",
                 "de": "Das json Property, welches den Wert für die Leistung enthält."
               }
+            },
+            {
+              "id": "measure_property_factor",
+              "type": "number",
+              "label": {
+                "en": "Value Property factor",
+                "de": "Faktor für Wert Eigenschaft"
+              },
+              "hint": {
+                "en": "The property of the incoming json that represents the measurement value.",
+                "de": "Das json Property, welches den Wert für die Leistung enthält."
+              }
             }
           ]
         },
@@ -131,6 +143,18 @@
               "label": {
                 "en": "Value Property",
                 "de": "Wert Eigenschaft"
+              },
+              "hint": {
+                "en": "The property of the incoming json that represents the metering value.",
+                "de": "Das json Property, welches den Wert für die Energie enthält."
+              }
+            },
+            {
+              "id": "meter_property_factor",
+              "type": "number",
+              "label": {
+                "en": "Value Property factor",
+                "de": "Faktor für Wert Eigenschaft"
               },
               "hint": {
                 "en": "The property of the incoming json that represents the metering value.",

--- a/drivers/energy-meter/access/MeterDevice.js
+++ b/drivers/energy-meter/access/MeterDevice.js
@@ -12,18 +12,24 @@ class MeterDevice {
       meter_power_url,
       measure_property,
       meter_property,
+      measure_property_factor,
+      meter_property_factor
     } = settings;
 
     this.measure_power_url = measure_power_url;
     this.meter_power_url = meter_power_url;
     this.measure_property = measure_property;
     this.meter_property = meter_property;
+    this.measure_property_factor = measure_property_factor;
+    this.meter_property_factor = meter_property_factor;
 
     this.device.log("Releading settings");
     this.device.log(`measure_power_url=${this.measure_power_url}`);
     this.device.log(`meter_power_url=${this.meter_power_url}`);
     this.device.log(`measure_property=${this.measure_property}`);
     this.device.log(`meter_property=${this.meter_property}`);
+    this.device.log(`measure_property_factor=${this.measure_property_factor}`);
+    this.device.log(`meter_property_factor=${this.meter_property_factor}`);
   }
 
   async start() {
@@ -50,7 +56,7 @@ class MeterDevice {
         this.device.log("Actual=" + value);
 
         this.device
-          .setCapabilityValue("measure_power", value)
+          .setCapabilityValue("measure_power", value * this.measure_property_factor)
           .catch(theDevice.error);
       }
     } catch (error) {}
@@ -68,7 +74,7 @@ class MeterDevice {
         this.device.log("Total=" + value);
 
         this.device
-          .setCapabilityValue("meter_power", value)
+          .setCapabilityValue("meter_power", value * this.meter_property_factor)
           .catch(theDevice.error);
       }
     } catch (error) {}

--- a/drivers/energy-meter/access/MeterDevice.js
+++ b/drivers/energy-meter/access/MeterDevice.js
@@ -43,15 +43,14 @@ class MeterDevice {
 
       if (response.ok) {
         var json = await response.json();
-        if (json === undefined) return;
+        const value = this.getPropertyValue(this.measure_property, json);
 
-        if (!json.hasOwnProperty(this.measure_property)) return;
+        if (!value) return;
 
-        var actual = json[this.measure_property];
-        this.device.log("Actual=" + actual);
+        this.device.log("Actual=" + value);
 
         this.device
-          .setCapabilityValue("measure_power", actual)
+          .setCapabilityValue("measure_power", value)
           .catch(theDevice.error);
       }
     } catch (error) {}
@@ -62,19 +61,27 @@ class MeterDevice {
       const response = await fetch(this.meter_power_url);
 
       if (response.ok) {
-        var json = await response.json();
-        if (json === undefined) return;
+        var json = await response.json();  
+        const value = this.getPropertyValue(this.meter_property, json);
+        if (!value) return;
 
-        if (!json.hasOwnProperty(this.meter_property)) return;
-
-        var total = json[this.meter_property];
-        this.device.log("Total=" + total);
+        this.device.log("Total=" + value);
 
         this.device
-          .setCapabilityValue("meter_power", total)
+          .setCapabilityValue("meter_power", value)
           .catch(theDevice.error);
       }
     } catch (error) {}
+  }
+
+/**
+ * 
+ * @param {*} path path.to.property
+ * @param {*} object 
+ * @returns null if property not found
+ */
+  getPropertyValue(path, object) {
+    return path.split('.').reduce((p,c)=>p&&p[c]||null, object);
   }
 
   async updateDeviceState() {

--- a/drivers/energy-meter/access/MeterPair.js
+++ b/drivers/energy-meter/access/MeterPair.js
@@ -8,6 +8,8 @@ class MeterPair {
     this.measure_property = "";
     this.meter_power_url = "";
     this.meter_property = "";
+    this.measure_property_factor = 1.0;
+    this.meter_property_factor = 1.0;
     this.devices = [];
   }
 
@@ -98,6 +100,8 @@ class MeterPair {
             meter_power_url: this.meter_power_url,
             measure_property: this.measure_property,
             meter_property: this.meter_property,
+            measure_property_factor: this.measure_property_factor,
+            meter_property_factor: this.meter_property_factor
           },
         },
       ];

--- a/drivers/energy-meter/access/MeterPair.js
+++ b/drivers/energy-meter/access/MeterPair.js
@@ -101,7 +101,8 @@ class MeterPair {
             measure_property: this.measure_property,
             meter_property: this.meter_property,
             measure_property_factor: this.measure_property_factor,
-            meter_property_factor: this.meter_property_factor
+            meter_property_factor: this.meter_property_factor,
+            is_solarpanel: false 
           },
         },
       ];

--- a/drivers/energy-meter/device.js
+++ b/drivers/energy-meter/device.js
@@ -10,6 +10,11 @@ class HttpEnergyMeterDevice extends Homey.Device {
   async onInit() {
     var settings = this.getSettings();
 
+    if(settings.is_solarpanel) {
+      this.setClass("solarpanel");
+      this.setEnergy(Object); // remove the energys object "cumulative"
+    }
+
     this.log(`HttpEnergyMeterDevice has been initialized`);
 
     this.meter = new MeterDevice(settings, this);
@@ -40,6 +45,8 @@ class HttpEnergyMeterDevice extends Homey.Device {
     this.log("OldSettings=" + strOldSettings);
     this.log("NewSettings=" + strNewSettings);
     this.log("ChangedKeys=" + strChangedKeys);
+
+
 
     await this.meter.stop();
     await this.meter.reloadSettings(newSettings);

--- a/drivers/energy-meter/driver.compose.json
+++ b/drivers/energy-meter/driver.compose.json
@@ -46,6 +46,18 @@
             "en": "The property of the incoming json that represents the measurement value.",
             "de": "Das json Property, welches den Wert für die Leistung enthält."
           }
+        },
+        {
+          "id": "measure_property_factor",
+          "type": "number",
+          "label": {
+            "en": "Value Property factor",
+            "de": "Faktor für Wert Eigenschaft"
+          },
+          "hint": {
+            "en": "A factor to scale the measurement value.",
+            "de": "Ein Faktor zum skalieren des Messwertes"
+          }
         }
       ]
     },
@@ -78,6 +90,18 @@
           "hint": {
             "en": "The property of the incoming json that represents the metering value.",
             "de": "Das json Property, welches den Wert für die Energie enthält."
+          }
+        },
+        {
+          "id": "meter_property_factor",
+          "type": "number",
+          "label": {
+            "en": "Value Property factor",
+            "de": "Faktor für Wert Eigenschaft"
+          },
+          "hint": {
+            "en": "A factor to scale the measurement value.",
+            "de": "Ein Faktor zum skalieren des Messwertes"
           }
         }
       ]

--- a/drivers/energy-meter/driver.compose.json
+++ b/drivers/energy-meter/driver.compose.json
@@ -17,6 +17,19 @@
   },
   "settings": [
     {
+      "id": "is_solarpanel",
+      "type": "checkbox",
+      "value": false,
+      "label": {
+        "en": "Solar plant / Inverter",
+        "de": "Solaranlage / Wechselrichter"
+      },
+      "hint": {
+        "en": "Is the meter an Inverter of a solar plant?",
+        "de": "Ist der Zähler ein Wechselrichter einer Solaranlage?"
+      }
+    },
+    {
       "type": "group",
       "label": {
         "en": "Measure",


### PR DESCRIPTION
1. Access nested json properties. Specifiy as "path.to.value"
2. Option to scale the json values. If the json value is in Wh, scale by 0.001 to get kWh
3. Change the meter to "solarpanel" to display all correctly in the "Energy-Tab" (restart of the app is required)

The changes are primarily to allowing the integration of a small solar plant. I'm using a Shelly plus 1PM as metering device, but the official shelly implementation sucks ;-)

http://192.0.0.0/rpc/Switch.GetStatus?id=0
`
{"id":0, "source":"init", "output":true, "apower":597.0, "voltage":232.5, "current":2.543, "aenergy":{"total":22840.973,"by_minute":[1329.286,9921.212,9537.316],"minute_ts":1650108666},"temperature":{"tC":45.6, "tF":114.1}}
`

to get the "total" value as kWh select by "aenergy.total" and scale by 0.001 to get kWh.